### PR TITLE
fix(scripts): make 'component' flag required

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -45,6 +45,7 @@ def parse_arguments() -> argparse.Namespace:
                                      formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-c", "--component",
                         choices=components,
+                        required=True,
                         help="Target component to build:\n"
                              f"  {Component.LIB.value}: Java SCP library\n"
                              f"  {Component.DOC.value}: Java SCP library documentation")


### PR DESCRIPTION
Resolves #6 

Before:
```
$ python3 ./scripts/build.py
'None' component build is unsupported
```
Now:
```
$ python3 ./scripts/build.py
usage: Build Java SCP library sources and generate documentation [-h] -c {lib,doc} [-cb]
Build Java SCP library sources and generate documentation: error: the following arguments are required: -c/--component
```