### PR TITLE
refactor(scripts): simplify output directory structure

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -60,13 +60,13 @@ def build_java(clean_build: bool) -> None:
     remove_java_artifacts([
         Const.Path.JAVA_LIBS_DIR,
         Const.Path.JAVA_DOCS_DIR,
-        Const.Path.DELIVERABLES_JAVA_DIR])
+        Const.Path.OUT_LIB_DIR])
     gradle_project_build(clean_build)
     collect_java_artifacts()
 
 
 def build_javadoc() -> None:
-    remove_java_artifacts([Const.Path.DELIVERABLES_JAVA_DOC_DIR])
+    remove_java_artifacts([Const.Path.OUT_DOCS_DIR])
     gradle_project_doc_build()
     collect_java_doc_artifacts()
 
@@ -95,12 +95,12 @@ def build_gradle_cmd(action: str) -> str:
 
 def collect_java_artifacts() -> None:
     lib_artifacts_path = Const.Path.JAVA_LIBS_DIR / "*"
-    collect_artifacts(lib_artifacts_path, Const.Path.DELIVERABLES_JAVA_DIR)
+    collect_artifacts(lib_artifacts_path, Const.Path.OUT_LIB_DIR)
 
 
 def collect_java_doc_artifacts() -> None:
     doc_artifacts_path = Const.Path.JAVA_DOCS_DIR / "*"
-    collect_artifacts(doc_artifacts_path, Const.Path.DELIVERABLES_JAVA_DIR)
+    collect_artifacts(doc_artifacts_path, Const.Path.OUT_DOCS_DIR)
 
 
 if __name__ == "__main__":

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -24,9 +24,8 @@ class Const:
         # java dirs
         JAVA_BUILD_DIR = PROJECT_ROOT / "build"
         JAVA_LIBS_DIR = JAVA_BUILD_DIR / "libs"
-        JAVA_DOCS_DIR = JAVA_BUILD_DIR / "docs"
+        JAVA_DOCS_DIR = JAVA_BUILD_DIR / "docs" / "javadoc"
         # artifacts
         OUT_DIR = PROJECT_ROOT / ".out"
-        DELIVERABLES_OUT_DIR = OUT_DIR / "deliverables"
-        DELIVERABLES_JAVA_DIR = DELIVERABLES_OUT_DIR / "java"
-        DELIVERABLES_JAVA_DOC_DIR = DELIVERABLES_JAVA_DIR / "docs"
+        OUT_LIB_DIR = OUT_DIR / "lib"
+        OUT_DOCS_DIR = OUT_DIR / "javadoc"


### PR DESCRIPTION
Resolves #7 

Before:
```
.out/
└── deliverables
    └── java
        ├── javadoc
        │   ├── ...
        │   ├── index.html
        │   └── ...
        └── openscp-1.0.0.jar
```
After:
```
.out
├── javadoc
│   ├── ...
│   ├── index.html
│   └── ...
└── lib
    └── openscp-1.0.0.jar

```