### PR TITLE
fix(library): remove '&' from javadocs

### DIFF
--- a/docs/javadoc/com/samsung/openscp/Scp11KeyParams.html
+++ b/docs/javadoc/com/samsung/openscp/Scp11KeyParams.html
@@ -149,7 +149,7 @@ implements <a href="../../../com/samsung/openscp/ScpKeyParams.html" title="inter
               java.security.PrivateKey&nbsp;skOceEcka,
               java.util.List&lt;byte[]&gt;&nbsp;certificates,
               <a href="../../../com/samsung/openscp/AesAlg.html" title="enum in com.samsung.openscp">AesAlg</a>&nbsp;sessionKeysAlg)</code>
-<div class="block">SCP11a- & SCP11c-specific constructor</div>
+<div class="block">SCP11a- and SCP11c-specific constructor</div>
 </td>
 </tr>
 </table>
@@ -207,7 +207,7 @@ implements <a href="../../../com/samsung/openscp/ScpKeyParams.html" title="inter
                       java.security.PrivateKey&nbsp;skOceEcka,
                       java.util.List&lt;byte[]&gt;&nbsp;certificates,
                       <a href="../../../com/samsung/openscp/AesAlg.html" title="enum in com.samsung.openscp">AesAlg</a>&nbsp;sessionKeysAlg)</pre>
-<div class="block">SCP11a- & SCP11c-specific constructor</div>
+<div class="block">SCP11a- and SCP11c-specific constructor</div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
 <dd><code>keyRef</code> - the reference to the key set for associated SK.SD.ECKA</dd>

--- a/docs/javadoc/index-all.html
+++ b/docs/javadoc/index-all.html
@@ -370,7 +370,7 @@
 </dd>
 <dt><span class="memberNameLink"><a href="com/samsung/openscp/Scp11KeyParams.html#Scp11KeyParams-com.samsung.openscp.KeyRef-java.security.PublicKey-com.samsung.openscp.KeyRef-java.security.PrivateKey-java.util.List-com.samsung.openscp.AesAlg-">Scp11KeyParams(KeyRef, PublicKey, KeyRef, PrivateKey, List&lt;byte[]&gt;, AesAlg)</a></span> - Constructor for class com.samsung.openscp.<a href="com/samsung/openscp/Scp11KeyParams.html" title="class in com.samsung.openscp">Scp11KeyParams</a></dt>
 <dd>
-<div class="block">SCP11a- & SCP11c-specific constructor</div>
+<div class="block">SCP11a- and SCP11c-specific constructor</div>
 </dd>
 <dt><span class="memberNameLink"><a href="com/samsung/openscp/Scp11KeyParams.html#Scp11KeyParams-com.samsung.openscp.KeyRef-java.security.PublicKey-com.samsung.openscp.AesAlg-">Scp11KeyParams(KeyRef, PublicKey, AesAlg)</a></span> - Constructor for class com.samsung.openscp.<a href="com/samsung/openscp/Scp11KeyParams.html" title="class in com.samsung.openscp">Scp11KeyParams</a></dt>
 <dd>

--- a/src/main/java/com/samsung/openscp/Scp11KeyParams.java
+++ b/src/main/java/com/samsung/openscp/Scp11KeyParams.java
@@ -63,7 +63,7 @@ public class Scp11KeyParams implements ScpKeyParams {
     final AesAlg sessionKeysAlg;
 
     /**
-     * SCP11a- & SCP11c-specific constructor
+     * SCP11a- and SCP11c-specific constructor
      *
      * @param keyRef the reference to the key set for associated SK.SD.ECKA
      * @param pkSdEcka public key of the SD used for key agreement (PK.SD.ECKA)


### PR DESCRIPTION
Resolves #19 